### PR TITLE
feature: add /lfp_restrict and fix /restrict for type: lfp/lfp plus; also updated IMA level req

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ const {
     help_button_interaction
 } = require('./src/bot/commands/verify');
 const { sync_roles_command, sync_roles_interaction } = require('./src/bot/commands/sync_roles');
-const { guild_id, automod_channel, general_channel } = require('./src/bot/constants');
+const { guild_id, automod_channel, general_channel, qna_channel } = require('./src/bot/constants');
 const { blacklist_command, blacklist_interaction } = require('./src/bot/commands/blacklist');
 const { get_uuid_command, get_uuid_interaction } = require('./src/bot/commands/get_uuid');
 const { punishments_command, punishments_interaction } = require('./src/bot/commands/punishments');
@@ -37,6 +37,7 @@ const { fetch_guild_data, rank_guild_command, rank_guild_interaction } = require
 const { refresh_current_snapshot_command, refresh_current_snapshot_interaction, sync_all_guilds } = require('./src/bot/commands/refresh_current_snapshot');
 const { check_garden_command, check_garden_interaction } = require('./src/bot/commands/check_garden');
 const { track_user_command, track_user_interaction, process_active_tracking_sessions, stop_all_tracking } = require('./src/bot/commands/track_user');
+const PIN_THREAD_PARENT_IDS = [qna_channel];
 // Create a new client instance
 const client = new Client({ 
     intents: [
@@ -46,6 +47,20 @@ const client = new Client({
         GatewayIntentBits.DirectMessages
     ] 
 });
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const shouldAutoPinThread = thread => {
+    if (!PIN_THREAD_PARENT_IDS.length) return false;
+    return PIN_THREAD_PARENT_IDS.includes(thread.parentId);
+};
+
+const fetchStarterMessageWithRetry = async thread => {
+    let starter = await thread.fetchStarterMessage().catch(() => null);
+    if (starter) return starter;
+    await sleep(1500);
+    return thread.fetchStarterMessage().catch(() => null);
+};
 
 // Database connection
 const db = mysql.createPool({
@@ -221,6 +236,21 @@ client.on('interactionCreate', async interaction => {
                 await verify_interaction(interaction, db, { 'ign': interaction.fields.getTextInputValue('ign_input') });
                 break;
         }
+    }
+});
+
+client.on('threadCreate', async (thread, newlyCreated) => {
+    if (!newlyCreated) return;
+    if (!shouldAutoPinThread(thread)) return;
+
+    try {
+        const starterMessage = await fetchStarterMessageWithRetry(thread);
+        if (!starterMessage) return;
+        if (starterMessage.pinned) return;
+
+        await starterMessage.pin('Auto-pin thread starter message');
+    } catch (error) {
+        console.error('Error auto-pinning thread starter:', error);
     }
 });
 

--- a/app.js
+++ b/app.js
@@ -31,7 +31,7 @@ const {
     handle_guild_notify_invited
 } = require('./src/bot/commands/guild_apply');
 const { skycrypt_command, skycrypt_interaction } = require('./src/bot/commands/skycrypt');
-const { mute_command, restrict_command, ban_command, unban_command, ban_interaction, unban_interaction, punish_interaction, checkExpiredPunishments } = require('./src/bot/commands/mute_restrict_ban');
+const { mute_command, restrict_command, lfp_restrict_command, ban_command, unban_command, ban_interaction, unban_interaction, lfp_restrict_interaction, punish_interaction, checkExpiredPunishments } = require('./src/bot/commands/mute_restrict_ban');
 const { autosync_roles_all_guilds } = require('./src/bot/commands/autosync_roles');
 const { fetch_guild_data, rank_guild_command, rank_guild_interaction } = require('./src/bot/commands/rank_guild');
 const { refresh_current_snapshot_command, refresh_current_snapshot_interaction, sync_all_guilds } = require('./src/bot/commands/refresh_current_snapshot');
@@ -99,6 +99,7 @@ async function registerSlashCommands() {
         skycrypt_command,
         mute_command,
         restrict_command,
+        lfp_restrict_command,
         ban_command,
         unban_command,
         rank_guild_command,
@@ -158,6 +159,9 @@ client.on('interactionCreate', async interaction => {
                 break;
             case 'restrict':
                 await punish_interaction(interaction, db);
+                break;
+            case 'lfp_restrict':
+                await lfp_restrict_interaction(interaction, db);
                 break;
             case 'ban':
                 await ban_interaction(interaction, db);

--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ const {
     help_button_interaction
 } = require('./src/bot/commands/verify');
 const { sync_roles_command, sync_roles_interaction } = require('./src/bot/commands/sync_roles');
-const { guild_id, automod_channel, general_channel, qna_channel } = require('./src/bot/constants');
+const { guild_id, automod_channel, general_channel, qna_channel, log_channel } = require('./src/bot/constants');
 const { blacklist_command, blacklist_interaction } = require('./src/bot/commands/blacklist');
 const { get_uuid_command, get_uuid_interaction } = require('./src/bot/commands/get_uuid');
 const { punishments_command, punishments_interaction } = require('./src/bot/commands/punishments');
@@ -62,6 +62,17 @@ const fetchStarterMessageWithRetry = async thread => {
     return thread.fetchStarterMessage().catch(() => null);
 };
 
+const sendLogMessage = async (client, content) => {
+    try {
+        const channel = await client.channels.fetch(log_channel);
+        if (channel && channel.isTextBased()) {
+            await channel.send(content);
+        }
+    } catch (error) {
+        console.error('Error sending log message:', error);
+    }
+};
+
 // Database connection
 const db = mysql.createPool({
     host: process.env.DB_HOST,
@@ -89,9 +100,12 @@ client.once('ready', async () => {
     setInterval(async () => {
         try {
             const results = await sync_all_guilds(db, client);
-            console.log('Auto sync_current_guild_members:\n' + results.join('\n'));
+            const logText = 'Auto sync_current_guild_members:\n' + results.join('\n');
+            console.log(logText);
+            await sendLogMessage(client, logText);
         } catch (err) {
             console.error('Auto sync_current_guild_members failed:', err);
+            await sendLogMessage(client, 'Auto sync_current_guild_members failed: ' + (err?.message || err));
         }
     }, 24 * 60 * 60 * 1000); // Sync guild members every day
     setInterval(async () => {

--- a/src/bot/commands/mute_restrict_ban.js
+++ b/src/bot/commands/mute_restrict_ban.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 const { punishments_interaction } = require('./punishments');
-const { ims_bot_id, punishment_log_channel, lfp_access_role, lfp_plus_access_role, bridge_access_role, muted_role, restricted_role, ticket_restricted_role, flex_restricted_role, qna_restricted_role, suggestion_restricted_role, hos_restricted_role, vc_restricted_role, lfp_restricted_role, lfp_plus_restricted_role, bridge_restricted_role, xp_restricted_role, appeals_server, cheater_role } = require('../constants');
+const { ims_bot_id, punishment_log_channel, lfp_punishment_log_channel, lfp_access_role, lfp_plus_access_role, bridge_access_role, muted_role, restricted_role, ticket_restricted_role, flex_restricted_role, qna_restricted_role, suggestion_restricted_role, hos_restricted_role, vc_restricted_role, lfp_restricted_role, lfp_plus_restricted_role, bridge_restricted_role, xp_restricted_role, appeals_server, cheater_role } = require('../constants');
 const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 const { log_action } = require('./log_action');
 
@@ -63,6 +63,42 @@ const restrict_command = new SlashCommandBuilder()
     .addBooleanOption(option =>
         option.setName('silent')
             .setDescription('Do not log this restriction')
+            .setRequired(false));
+
+const lfp_restrict_command = new SlashCommandBuilder()
+    .setName('lfp_restrict')
+    .setDescription('Restrict a user from LFP/LFP+')
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+    .setDMPermission(false)
+    .addMentionableOption(option =>
+        option.setName('user')
+            .setDescription('The user to restrict')
+            .setRequired(true))
+    .addStringOption(option =>
+        option.setName('type')
+            .setDescription('Type of LFP restriction')
+            .setRequired(true)
+            .addChoices(
+                { name: 'Talking outside of threads', value: 'talk_outside_threads' },
+                { name: 'Re-opening/extending thread length', value: 'reopen_extend_thread' },
+                { name: 'Misuse of ping', value: 'misuse_ping' },
+                { name: 'Ghost pinging', value: 'ghost_pinging' },
+                { name: 'Troll pinging', value: 'troll_pinging' },
+                { name: 'Sending unrelated images', value: 'unrelated_images' },
+                { name: 'Warping other users in', value: 'warp_users' },
+                { name: 'Griefing', value: 'griefing' },
+                { name: 'Using LFP+ from normal profile', value: 'lfp_plus_normal_profile' },
+                { name: 'Mass pinging', value: 'mass_pinging' },
+                { name: 'LFP custom duration', value: 'lfp_custom' },
+                { name: 'LFP+ custom duration', value: 'lfp_plus_custom' }
+            ))
+    .addStringOption(option =>
+        option.setName('duration')
+            .setDescription('Restrict duration (e.g., 1s, 1m, 1h, 1d, 1w, perm)')
+            .setRequired(false))
+    .addStringOption(option =>
+        option.setName('reason')
+            .setDescription('Reason for restricting')
             .setRequired(false));
 
 const ban_command = new SlashCommandBuilder()
@@ -210,6 +246,212 @@ const unban_interaction = async (interaction, db) => {
     }
 }
 
+const lfp_restrict_interaction = async (interaction, db) => {
+    interaction.deferReply();
+    const user = interaction.options.getUser('user');
+    const type = interaction.options.getString('type');
+    const durationInput = interaction.options.getString('duration');
+    const reasonInput = interaction.options.getString('reason');
+
+    let punishment_type = 'lfp';
+    let duration;
+    let reason;
+    let requiresDuration = false;
+    let typeLabel = 'LFP restriction';
+
+    switch (type) {
+        case 'talk_outside_threads':
+            duration = '1d';
+            reason = 'Talking outside of threads';
+            typeLabel = 'Talking outside of threads';
+            break;
+        case 'reopen_extend_thread':
+            duration = '1d';
+            reason = 'Re-opening/extending thread length';
+            typeLabel = 'Re-opening/extending thread length';
+            break;
+        case 'misuse_ping':
+            duration = '1d';
+            reason = 'Misuse of ping';
+            typeLabel = 'Misuse of ping';
+            break;
+        case 'ghost_pinging':
+            duration = '3d';
+            reason = 'Ghost pinging';
+            typeLabel = 'Ghost pinging';
+            break;
+        case 'troll_pinging':
+            duration = '1w';
+            reason = 'Troll pinging';
+            typeLabel = 'Troll pinging';
+            break;
+        case 'unrelated_images':
+            duration = '1w';
+            reason = 'Sending unrelated images';
+            typeLabel = 'Sending unrelated images';
+            break;
+        case 'warp_users':
+            duration = 'perm';
+            reason = 'Warping other users in';
+            typeLabel = 'Warping other users in';
+            break;
+        case 'griefing':
+            duration = 'perm';
+            reason = 'Griefing';
+            typeLabel = 'Griefing';
+            break;
+        case 'mass_pinging':
+            duration = 'perm';
+            reason = 'Mass pinging';
+            typeLabel = 'Mass pinging';
+            break;
+        case 'lfp_plus_normal_profile':
+            punishment_type = 'lfp_plus';
+            duration = 'perm';
+            reason = 'Using LFP+ from a normal profile';
+            typeLabel = 'Using LFP+ from a normal profile';
+            break;
+        case 'lfp_custom':
+            punishment_type = 'lfp';
+            requiresDuration = true;
+            duration = durationInput;
+            reason = 'LFP restriction';
+            typeLabel = 'LFP custom';
+            break;
+        case 'lfp_plus_custom':
+            punishment_type = 'lfp_plus';
+            requiresDuration = true;
+            duration = durationInput;
+            reason = 'LFP+ restriction';
+            typeLabel = 'LFP+ custom';
+            break;
+        default:
+            return interaction.editReply('Invalid LFP restriction type.');
+    }
+
+    if (requiresDuration && !duration) {
+        return interaction.editReply('Duration is required for custom LFP restrictions.');
+    }
+
+    if (reasonInput && reasonInput.trim().length > 0) {
+        reason = reasonInput;
+    }
+
+    const durationInMs = parseDuration(duration);
+    if (!durationInMs) {
+        return interaction.editReply('Invalid duration format. Please use formats like 1h, 1d, or 1w.');
+    }
+
+    const endTime = Date.now() + durationInMs;
+
+    try {
+        let sql = 'SELECT * FROM current_punishments WHERE user_id = ? AND guild_id = ? AND punishment_type = ?';
+        const [rows] = await db.query(sql, [user.id, interaction.guildId, punishment_type]);
+        if (rows.length > 0) {
+            sql = 'UPDATE current_punishments SET end_time = ? WHERE id = ?';
+            await db.query(sql, [endTime, rows[0].id]);
+        }
+
+        if (duration !== 'perm' || punishment_type === 'lfp_plus') {
+            sql = 'INSERT INTO current_punishments (user_id, guild_id, end_time, reason, punishment_type) VALUES (?, ?, ?, ?, ?)';
+            await db.query(sql, [user.id, interaction.guildId, endTime, reason, punishment_type]);
+        }
+
+        const member = await interaction.guild.members.fetch(user.id);
+        if (punishment_type === 'lfp') {
+            await member.roles.add(lfp_restricted_role);
+        }
+        else {
+            await member.roles.add(lfp_plus_restricted_role);
+            await member.roles.add(lfp_restricted_role);
+        }
+        await member.roles.remove(lfp_access_role);
+        await member.roles.remove(lfp_plus_access_role);
+
+        if (punishment_type === 'lfp_plus') {
+            let lfp_end_time = Date.now() + durationInMs;
+            if (duration === 'perm') {
+                lfp_end_time = Date.now() + 30 * 24 * 60 * 60 * 1000;
+            }
+
+            let sql = 'SELECT * FROM current_punishments WHERE user_id = ? AND guild_id = ? AND punishment_type = ?';
+            const [lfpRows] = await db.query(sql, [user.id, interaction.guildId, 'lfp']);
+            if (lfpRows.length > 0) {
+                const original_lfp_end_time = lfpRows[0].end_time;
+                if (lfp_end_time > original_lfp_end_time) {
+                    sql = 'UPDATE current_punishments SET end_time = ? WHERE id = ?';
+                    await db.query(sql, [lfp_end_time, lfpRows[0].id]);
+                }
+            } else {
+                sql = 'INSERT INTO current_punishments (user_id, guild_id, end_time, reason, punishment_type) VALUES (?, ?, ?, ?, ?)';
+                const lfp_reason = duration === 'perm' ? '30 day LFP ban with LFP+ ban' : reason;
+                await db.query(sql, [user.id, interaction.guildId, lfp_end_time, lfp_reason, 'lfp']);
+            }
+        }
+
+        const punishmentLogChannel = await interaction.guild.channels.fetch(lfp_punishment_log_channel);
+        const fakeInteraction = {
+            options: {
+                getMentionable: () => ({ id: user.id }),
+                getSubcommand: () => 'add',
+                getString: (name) => {
+                    if (name === 'punishment') {
+                        return `${duration} ${punishment_type} restricted`;
+                    }
+                    else if (name === 'reason') {
+                        return reason;
+                    }
+                    else {
+                        return null;
+                    }
+                }
+            },
+            reply: async (content) => {
+                await punishmentLogChannel.send(content);
+            },
+            fetchReply: async () => {
+                const messages = await punishmentLogChannel.messages.fetch({ limit: 1 });
+                return messages.first();
+            },
+            guildId: interaction.guildId,
+            channelId: lfp_punishment_log_channel,
+            createdTimestamp: interaction.createdTimestamp,
+            user: interaction.user,
+            client: interaction.client
+        };
+
+        await punishments_interaction(fakeInteraction, db, 'add');
+
+        let punishmentSummary = `${duration} ${punishment_type.toUpperCase()} restriction`;
+        if (punishment_type === 'lfp_plus') {
+            if (duration === 'perm') {
+                punishmentSummary = 'perm LFP+ restriction + 30d LFP restriction';
+            } else {
+                punishmentSummary = `${duration} LFP+ restriction + ${duration} LFP restriction`;
+            }
+        }
+        let dm_string = `You have been ${punishment_type} restricted in ${interaction.guild.name} for ${duration}. \nReason: ${reason}`;
+        try {
+            await user.send(dm_string);
+        } catch (error) {
+            console.error(`Failed to send DM to ${user.tag}: ${error}`);
+        }
+
+        const typeLine = `Type: ${typeLabel}`;
+        const reasonLine = (reason && reason.trim().toLowerCase() !== typeLabel.trim().toLowerCase())
+            ? `\nReason: ${reason}`
+            : '';
+        let punishment_string = `**${interaction.user}** ${punishment_type} restricted <@${user.id}> for ${duration}. \n${typeLine}\nPunishment: ${punishmentSummary}${reasonLine}`;
+        let punishment_type_string = punishment_type + ' restricted';
+        await log_action(interaction.client, `${punishment_type_string}`, interaction.user, `${user.id}`, punishment_string);
+        await interaction.editReply(punishment_string);
+
+    } catch (error) {
+        console.error('Error applying LFP restriction:', error);
+        interaction.editReply(`An error occurred while trying to punish the user: ${error}`);
+    }
+};
+
 const punish_interaction = async (interaction, db, punishment_type) => {
     interaction.deferReply();
     const user = interaction.options.getUser('user');
@@ -294,7 +536,7 @@ const punish_interaction = async (interaction, db, punishment_type) => {
         if (duration === 'perm') {
             console.log('   Permanent punishment applied');
         }
-        else {
+        if (duration !== 'perm' || punishment_type === 'lfp_plus') {
             sql = 'INSERT INTO current_punishments (user_id, guild_id, end_time, reason, punishment_type) VALUES (?, ?, ?, ?, ?)';
             await db.query(sql, [user.id, interaction.guildId, endTime, reason, punishment_type]);
         }
@@ -308,10 +550,8 @@ const punish_interaction = async (interaction, db, punishment_type) => {
             await member.roles.remove(lfp_plus_access_role)
             await member.roles.remove(lfp_access_role)
 
-            
             let lfp_end_time;
             if (duration === 'perm') {
-                // 30 day lfp ban for permanent punishment
                 lfp_end_time = Date.now() + 30 * 24 * 60 * 60 * 1000;
             }
             else {
@@ -321,21 +561,20 @@ const punish_interaction = async (interaction, db, punishment_type) => {
             let sql = 'SELECT * FROM current_punishments WHERE user_id = ? AND guild_id = ? AND punishment_type = ?';
             const [rows] = await db.query(sql, [user.id, interaction.guildId, 'lfp']);
             if (rows.length > 0) {
-                original_lfp_end_time = rows[0].end_time;
-
-                // Replace original end time with longer end time
+                const original_lfp_end_time = rows[0].end_time;
                 if (lfp_end_time > original_lfp_end_time) {
                     sql = 'UPDATE current_punishments SET end_time = ? WHERE id = ?';
                     await db.query(sql, [lfp_end_time, rows[0].id]);
                 }
             } else {
                 sql = 'INSERT INTO current_punishments (user_id, guild_id, end_time, reason, punishment_type) VALUES (?, ?, ?, ?, ?)';
-                await db.query(sql, [user.id, interaction.guildId, Date.now() + 30 * 24 * 60 * 60 * 1000, '30 day LFP ban with LFP+ ban', 'lfp']);
+                const lfp_reason = duration === 'perm' ? '30 day LFP ban with LFP+ ban' : reason;
+                await db.query(sql, [user.id, interaction.guildId, lfp_end_time, lfp_reason, 'lfp']);
             }
-
         }
         if (punishment_type === 'lfp') {
             await member.roles.remove(lfp_access_role)
+            await member.roles.remove(lfp_plus_access_role)
         }
         if (punishment_type === 'bridge') {
             await member.roles.remove(bridge_access_role)
@@ -343,7 +582,10 @@ const punish_interaction = async (interaction, db, punishment_type) => {
 
         if (!silent) {
             // Create a separate channel object for the punishment log
-            const punishmentLogChannel = await interaction.guild.channels.fetch(punishment_log_channel);
+            const logChannelId = (punishment_type === 'lfp' || punishment_type === 'lfp_plus')
+                ? lfp_punishment_log_channel
+                : punishment_log_channel;
+            const punishmentLogChannel = await interaction.guild.channels.fetch(logChannelId);
 
             // Modify the fakeInteraction to use the punishment log channel
             const fakeInteraction = {
@@ -380,7 +622,7 @@ const punish_interaction = async (interaction, db, punishment_type) => {
                     return messages.first();
                 },
                 guildId: interaction.guildId,
-                channelId: punishment_log_channel,
+                channelId: logChannelId,
                 createdTimestamp: interaction.createdTimestamp,
                 user: interaction.user,
                 client: interaction.client
@@ -534,4 +776,4 @@ async function checkExpiredPunishments(client, db) {
     }
 }
 
-module.exports = { mute_command, restrict_command, ban_command, unban_command, ban_interaction, unban_interaction, punish_interaction, checkExpiredPunishments };
+module.exports = { mute_command, restrict_command, lfp_restrict_command, ban_command, unban_command, ban_interaction, unban_interaction, lfp_restrict_interaction, punish_interaction, checkExpiredPunishments };

--- a/src/bot/commands/refresh_current_snapshot.js
+++ b/src/bot/commands/refresh_current_snapshot.js
@@ -7,7 +7,8 @@ const {
     ima_guild_id,
     ims_guild_role,
     imc_guild_role,
-    ima_guild_role
+    ima_guild_role,
+    log_channel
 } = require('../constants');
 
 const API_KEY = process.env.HYPIXEL_API_KEY;
@@ -166,16 +167,21 @@ async function markCurrentMembers(db, guildId, memberUUIDs) {
 }
 
 async function removeDiscordRoles(client, roleId, discordUserIds) {
-    if (!discordUserIds.length) return { removed: 0, errors: 0 };
+    if (!discordUserIds.length) return { removed: 0, errors: 0, errorDetails: [] };
     let removed = 0;
     let errors = 0;
+    const errorDetails = [];
     const chunkSize = 50;
     let guild;
     try {
         guild = await client.guilds.fetch(discord_guild_id);
     } catch (err) {
         console.error('Failed to fetch Discord guild for role removals:', err);
-        return { removed: 0, errors: discordUserIds.length };
+        return {
+            removed: 0,
+            errors: discordUserIds.length,
+            errorDetails: discordUserIds.map(id => ({ discordId: id, error: err.message || String(err) }))
+        };
     }
 
     for (let i = 0; i < discordUserIds.length; i += chunkSize) {
@@ -189,24 +195,30 @@ async function removeDiscordRoles(client, roleId, discordUserIds) {
                 }
             } catch (err) {
                 errors += 1;
+                errorDetails.push({ discordId: userId, error: err.message || String(err) });
                 console.error(`Failed to remove role for ${userId}:`, err.message);
             }
         }
     }
-    return { removed, errors };
+    return { removed, errors, errorDetails };
 }
 
 async function addDiscordRoles(client, roleId, discordUserIds) {
-    if (!discordUserIds.length) return { added: 0, errors: 0 };
+    if (!discordUserIds.length) return { added: 0, errors: 0, errorDetails: [] };
     let added = 0;
     let errors = 0;
+    const errorDetails = [];
     const chunkSize = 50;
     let guild;
     try {
         guild = await client.guilds.fetch(discord_guild_id);
     } catch (err) {
         console.error('Failed to fetch Discord guild for role additions:', err);
-        return { added: 0, errors: discordUserIds.length };
+        return {
+            added: 0,
+            errors: discordUserIds.length,
+            errorDetails: discordUserIds.map(id => ({ discordId: id, error: err.message || String(err) }))
+        };
     }
 
     for (let i = 0; i < discordUserIds.length; i += chunkSize) {
@@ -220,11 +232,30 @@ async function addDiscordRoles(client, roleId, discordUserIds) {
                 }
             } catch (err) {
                 errors += 1;
+                errorDetails.push({ discordId: userId, error: err.message || String(err) });
                 console.error(`Failed to add role for ${userId}:`, err.message);
             }
         }
     }
-    return { added, errors };
+    return { added, errors, errorDetails };
+}
+
+async function formatRoleErrorDetails(db, errorDetails, label) {
+    if (!errorDetails.length) return [];
+    const uniqueIds = [...new Set(errorDetails.map(e => e.discordId))];
+    const [rows] = await db.query(
+        'SELECT discord_id, ign, uuid FROM members WHERE discord_id IN (?)',
+        [uniqueIds]
+    );
+    const byDiscordId = new Map(rows.map(r => [r.discord_id, r]));
+    const lines = [`  ${label}:`];
+    for (const err of errorDetails) {
+        const row = byDiscordId.get(err.discordId);
+        const ign = row?.ign ? row.ign : 'unknown';
+        const uuid = row?.uuid ? row.uuid : 'unknown';
+        lines.push(`  - discord_id=${err.discordId} ign=${ign} uuid=${uuid} error=${err.error}`);
+    }
+    return lines;
 }
 
 async function sync_all_guilds(db, client, targetGuildIds = null) {
@@ -239,8 +270,8 @@ async function sync_all_guilds(db, client, targetGuildIds = null) {
             const { added, removed, addedList, removedList, inserted } = await markCurrentMembers(db, id, uuids);
 
             const roleId = roleByGuildId.get(id);
-            let roleRemovals = { removed: 0, errors: 0 };
-            let roleAdditions = { added: 0, errors: 0 };
+            let roleRemovals = { removed: 0, errors: 0, errorDetails: [] };
+            let roleAdditions = { added: 0, errors: 0, errorDetails: [] };
 
             if (roleId && removedList.length > 0) {
                 const [rows] = await db.query(
@@ -264,7 +295,15 @@ async function sync_all_guilds(db, client, targetGuildIds = null) {
                 }
             }
 
-            results.push(`${name} : api=${uuids.length}, inserted=${inserted}, added=${added}, removed=${removed}, role adds=${roleAdditions.added}, add errors=${roleAdditions.errors}, role removals=${roleRemovals.removed}, remove errors=${roleRemovals.errors}`);
+            const summary = `${name} : api=${uuids.length}, inserted=${inserted}, added=${added}, removed=${removed}, role adds=${roleAdditions.added}, add errors=${roleAdditions.errors}, role removals=${roleRemovals.removed}, remove errors=${roleRemovals.errors}`;
+            const detailLines = [];
+            if (roleAdditions.errorDetails.length) {
+                detailLines.push(...await formatRoleErrorDetails(db, roleAdditions.errorDetails, 'Role add errors'));
+            }
+            if (roleRemovals.errorDetails.length) {
+                detailLines.push(...await formatRoleErrorDetails(db, roleRemovals.errorDetails, 'Role removal errors'));
+            }
+            results.push(detailLines.length ? `${summary}\n${detailLines.join('\n')}` : summary);
         } catch (err) {
             console.error(`Error refreshing current_snapshot for ${name}:`, err);
             results.push(`${name} : error - ${err.message}`);
@@ -278,7 +317,16 @@ const refresh_current_snapshot_interaction = async (interaction, db, client) => 
     const selectedGuildId = interaction.options.getString('guild');
     const targetIds = selectedGuildId && selectedGuildId !== 'all' ? [selectedGuildId] : null;
     const results = await sync_all_guilds(db, client, targetIds);
-    await interaction.editReply(`Refresh complete:\n${results.join('\n')}`);
+    const replyText = `Refresh complete:\n${results.join('\n')}`;
+    await interaction.editReply(replyText);
+    try {
+        const channel = await client.channels.fetch(log_channel);
+        if (channel && channel.isTextBased()) {
+            await channel.send(`Manual sync_current_guild_members by <@${interaction.user.id}>:\n${results.join('\n')}`);
+        }
+    } catch (err) {
+        console.error('Failed to send manual sync log message:', err);
+    }
 };
 
 module.exports = {

--- a/src/bot/constants.js
+++ b/src/bot/constants.js
@@ -42,6 +42,7 @@ const xp_restricted_role = '1281754617428049951';
 const automod_channel = '1346625724865318912';
 const general_channel = '1346623017878552726';
 const punishment_log_channel = '1346625649590403162';
+const lfp_punishment_log_channel = '1433075278065963080';
 const alerts_channel = '1346624501106081873';
 const tracking_channel = '1381410909938913310';
 const log_channel = '1388919866731266169';
@@ -110,6 +111,7 @@ module.exports = {
     automod_channel, 
     general_channel, 
     punishment_log_channel,
+    lfp_punishment_log_channel,
     alerts_channel,
     tracking_channel,
     log_channel,

--- a/src/bot/constants.js
+++ b/src/bot/constants.js
@@ -46,6 +46,7 @@ const lfp_punishment_log_channel = '1433075278065963080';
 const alerts_channel = '1346624501106081873';
 const tracking_channel = '1381410909938913310';
 const log_channel = '1388919866731266169';
+const qna_channel = '1346682473870000208';
 
 const ims_members_channel = '1348459267442606081';
 const imc_members_channel = '1348459500281270303';
@@ -108,6 +109,7 @@ module.exports = {
     lfp_plus_restricted_role,
     bridge_restricted_role,
     xp_restricted_role,
+    qna_channel,
     automod_channel, 
     general_channel, 
     punishment_log_channel,

--- a/src/bot/constants.js
+++ b/src/bot/constants.js
@@ -50,7 +50,7 @@ const ims_members_channel = '1348459267442606081';
 const imc_members_channel = '1348459500281270303';
 const ima_members_channel = '1348459567335473203';
 
-const IMA_req = 200;
+const IMA_req = 240;
 const IMC_req = 360;
 const IMS_req = 440;
 


### PR DESCRIPTION
**Summary**

- Added /lfp_restrict with preset offense types and optional duration/reason.
- Centralized all LFP/LFP+ punishments records into lfp-punishment-log.
- Modified LFP/LFP+ restriction role handling, for example removing lfp plus access role when lfp restricting someone.
- Changed IMA joining req to 240 
- Added auto pin for qna threads
- Added error logs for /sync_current_guild_members in ims-bot-logs channel
