### PR TITLE
Improve Discord interaction handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -146,103 +146,123 @@ async function registerSlashCommands() {
     }
 }
 
-client.on('interactionCreate', async interaction => {
-    if (interaction.isChatInputCommand()) {
-        switch (interaction.commandName) {
-            case 'verify':
-                await verify_interaction(interaction, db);
-                break;
-            case 'sync-roles':
-                await sync_roles_interaction(interaction, db);
-                break;
-            case 'blacklist':
-                await blacklist_interaction(interaction, db);
-                break;
-            case 'get_uuid':
-                await get_uuid_interaction(interaction, db);
-                break;
-            case 'punishments':
-                await punishments_interaction(interaction, db, null);
-                break;
-            case 'setup_apply':
-                await setup_apply_interaction(interaction);
-                break;
-            case 'setup_verify':
-                await setup_verify_interaction(interaction);
-                break;
-            case 'help_verify':
-                await help_verify_interaction(interaction);
-                break;
-            case 'skycrypt':
-                await skycrypt_interaction(interaction, db);
-                break;
-            case 'mute':
-                await punish_interaction(interaction, db, 'mute');
-                break;
-            case 'restrict':
-                await punish_interaction(interaction, db);
-                break;
-            case 'lfp_restrict':
-                await lfp_restrict_interaction(interaction, db);
-                break;
-            case 'ban':
-                await ban_interaction(interaction, db);
-                break;
-            case 'unban':
-                await unban_interaction(interaction, db);
-                break;
-            case 'rank_guild':
-                await rank_guild_interaction(interaction, db);
-                break;
-            case 'check_garden':
-                await check_garden_interaction(interaction, db);
-                break;
-            case 'track_user':
-                await track_user_interaction(interaction, db, client);
-                break;
-            case 'sync_current_guild_members':
-                await refresh_current_snapshot_interaction(interaction, db, client);
-                break;
-        }
-    } 
-    else if (interaction.isButton()) {
-        if (interaction.customId.startsWith('apply_')) {
-            await handle_guild_selection(interaction, db, client);
+const replyToFailedInteraction = async (interaction) => {
+    if (!interaction.isRepliable()) return;
+
+    try {
+        const message = 'There was an error while processing this interaction.';
+        if (interaction.deferred || interaction.replied) {
+            await interaction.followUp({ content: message, ephemeral: true });
         } else {
-            switch (interaction.customId) {
-                case 'guild_accept':
-                    await handle_guild_accept(interaction, db, client);
+            await interaction.reply({ content: message, ephemeral: true });
+        }
+    } catch (replyError) {
+        console.error('Error replying to failed interaction:', replyError);
+    }
+};
+
+client.on('interactionCreate', async interaction => {
+    try {
+        if (interaction.isChatInputCommand()) {
+            switch (interaction.commandName) {
+                case 'verify':
+                    await verify_interaction(interaction, db);
                     break;
-                case 'guild_reject':
-                    await handle_guild_reject(interaction, db, client);
+                case 'sync-roles':
+                    await sync_roles_interaction(interaction, db);
                     break;
-                case 'application_close':
-                    await handle_application_close(interaction, db, client);
+                case 'blacklist':
+                    await blacklist_interaction(interaction, db);
                     break;
-                case 'guild_invited':
-                    await handle_guild_invited(interaction, db, client);
+                case 'get_uuid':
+                    await get_uuid_interaction(interaction, db);
                     break;
-                case 'guild_ask_to_leave':
-                    await handle_guild_ask_to_leave(interaction, db, client);
+                case 'punishments':
+                    await punishments_interaction(interaction, db, null);
                     break;
-                case 'guild_notify_invited':
-                    await handle_guild_notify_invited(interaction, db, client);
+                case 'setup_apply':
+                    await setup_apply_interaction(interaction);
                     break;
-                case 'verify_button':
-                    await verify_button_interaction(interaction, db);
+                case 'setup_verify':
+                    await setup_verify_interaction(interaction);
                     break;
-                case 'verify_help':
-                    await help_button_interaction(interaction);
+                case 'help_verify':
+                    await help_verify_interaction(interaction);
+                    break;
+                case 'skycrypt':
+                    await skycrypt_interaction(interaction, db);
+                    break;
+                case 'mute':
+                    await punish_interaction(interaction, db, 'mute');
+                    break;
+                case 'restrict':
+                    await punish_interaction(interaction, db);
+                    break;
+                case 'lfp_restrict':
+                    await lfp_restrict_interaction(interaction, db);
+                    break;
+                case 'ban':
+                    await ban_interaction(interaction, db);
+                    break;
+                case 'unban':
+                    await unban_interaction(interaction, db);
+                    break;
+                case 'rank_guild':
+                    await rank_guild_interaction(interaction, db);
+                    break;
+                case 'check_garden':
+                    await check_garden_interaction(interaction, db);
+                    break;
+                case 'track_user':
+                    await track_user_interaction(interaction, db, client);
+                    break;
+                case 'sync_current_guild_members':
+                    await refresh_current_snapshot_interaction(interaction, db, client);
                     break;
             }
         }
-    } 
-    else if (interaction.isModalSubmit()) {
-        switch(interaction.customId) {
-            case 'verification_form':
-                await verify_interaction(interaction, db, { 'ign': interaction.fields.getTextInputValue('ign_input') });
-                break;
+        else if (interaction.isButton()) {
+            if (interaction.customId.startsWith('apply_')) {
+                await handle_guild_selection(interaction, db, client);
+            } else {
+                switch (interaction.customId) {
+                    case 'guild_accept':
+                        await handle_guild_accept(interaction, db, client);
+                        break;
+                    case 'guild_reject':
+                        await handle_guild_reject(interaction, db, client);
+                        break;
+                    case 'application_close':
+                        await handle_application_close(interaction, db, client);
+                        break;
+                    case 'guild_invited':
+                        await handle_guild_invited(interaction, db, client);
+                        break;
+                    case 'guild_ask_to_leave':
+                        await handle_guild_ask_to_leave(interaction, db, client);
+                        break;
+                    case 'guild_notify_invited':
+                        await handle_guild_notify_invited(interaction, db, client);
+                        break;
+                    case 'verify_button':
+                        await verify_button_interaction(interaction, db);
+                        break;
+                    case 'verify_help':
+                        await help_button_interaction(interaction);
+                        break;
+                }
+            }
         }
+        else if (interaction.isModalSubmit()) {
+            switch(interaction.customId) {
+                case 'verification_form':
+                    await verify_interaction(interaction, db, { 'ign': interaction.fields.getTextInputValue('ign_input') });
+                    break;
+            }
+        }
+    } catch (error) {
+        console.error('Error handling interaction:', error);
+        await replyToFailedInteraction(interaction);
     }
 });
 
@@ -263,8 +283,6 @@ client.on('messageCreate', async message => {
     // Ignore messages not in IMS
     // if (message.guild.id !== guild_id) return;
     
-    const channel = await client.channels.fetch(automod_channel);
-
     // Ignore messages from bots
     if (message.author.bot) return;
 
@@ -311,6 +329,7 @@ client.on('messageCreate', async message => {
 
     // Automod messages using OpenAI Moderation API
     try {
+        const channel = await client.channels.fetch(automod_channel);
         await process_moderationapi_message(message, "https://api.openai.com/v1/moderations", channel, client);
         botStatus.apiWorking = true;
     } catch (error) {

--- a/src/bot/commands/blacklist.js
+++ b/src/bot/commands/blacklist.js
@@ -192,9 +192,13 @@ const blacklist_interaction = async (interaction, db) => {
                 });
             });
         
-            collector.on('end', () => {
+            collector.on('end', async () => {
                 row.components.forEach(button => button.setDisabled(true));
-                interaction.editReply({ components: [row] });
+                try {
+                    await interaction.editReply({ components: [row] });
+                } catch (error) {
+                    console.error('Error disabling blacklist pagination buttons:', error);
+                }
             });
         }
         else if (subcommand === 'view') {
@@ -266,9 +270,13 @@ const blacklist_interaction = async (interaction, db) => {
                 });
             });
         
-            collector.on('end', () => {
+            collector.on('end', async () => {
                 row.components.forEach(button => button.setDisabled(true));
-                interaction.editReply({ components: [row] });
+                try {
+                    await interaction.editReply({ components: [row] });
+                } catch (error) {
+                    console.error('Error disabling blacklist pagination buttons:', error);
+                }
             });
         }
     } catch (error) {

--- a/src/bot/commands/guild_apply.js
+++ b/src/bot/commands/guild_apply.js
@@ -121,14 +121,14 @@ const setup_apply_interaction = async (interaction) => {
         await interaction.reply({ content: 'Application button has been set up!', ephemeral: true });
     } catch (error) {
         console.error('Error setting up apply button:', error);
-        interaction.reply({ content: `An error occurred while setting up the apply button: ${error.message}`, ephemeral: true });
+        await interaction.reply({ content: `An error occurred while setting up the apply button: ${error.message}`, ephemeral: true });
     }
 }
 
 const create_application = async (interaction, db, client, member, ign, application_channel, staff_role, application_category, guildName) => {
     try {
         const channel = await client.channels.fetch(application_channel);
-        const applyMessage = await channel.send(`<@&${staff_role}>\n[${ign}](https://sky.shiiyu.moe/stats/${ign}) (${member}) has applied for ${guildName}!`);
+        const applyMessage = await channel.send(`<@&${staff_role}>\n[${ign}](https://sky.shiiiyu.moe/stats/${ign}) (${member}) has applied for ${guildName}!`);
 
         // Create a new channel in application_category
         const application = await interaction.guild.channels.create({
@@ -360,7 +360,7 @@ You can also type /guild accept ${gmIgn} to join.\n`
                 waitlist_channel = await client.channels.fetch(IMS_waitlist);
                 waitlist_message = await waitlist_channel.send(`${ign} (<@${userid}>) <#${application_channel}>`);
 
-                channel.send(`${ign} (<@${userid}>) has been accepted by ${interaction.user}!`);
+                await channel.send(`${ign} (<@${userid}>) has been accepted by ${interaction.user}!`);
                 accepted_message += `<#${IMS_waitlist}>`;
                 break;
             case 'Ironman Casuals':
@@ -368,7 +368,7 @@ You can also type /guild accept ${gmIgn} to join.\n`
                 waitlist_channel = await client.channels.fetch(IMC_waitlist);
                 waitlist_message = await waitlist_channel.send(`${ign} (<@${userid}>) <#${application_channel}>`);
 
-                channel.send(`${ign} (<@${userid}>) has been accepted by ${interaction.user}!`);
+                await channel.send(`${ign} (<@${userid}>) has been accepted by ${interaction.user}!`);
                 accepted_message += `<#${IMC_waitlist}>`;
                 break;
             case 'Ironman Academy':
@@ -376,7 +376,7 @@ You can also type /guild accept ${gmIgn} to join.\n`
                 waitlist_channel = await client.channels.fetch(IMA_waitlist);
                 waitlist_message = await waitlist_channel.send(`${ign} (<@${userid}>) <#${application_channel}>`);
 
-                channel.send(`${ign} (<@${userid}>) has been accepted by ${interaction.user}!`);
+                await channel.send(`${ign} (<@${userid}>) has been accepted by ${interaction.user}!`);
                 accepted_message += `<#${IMA_waitlist}>`;
                 break;
         }
@@ -410,15 +410,15 @@ You can also type /guild accept ${gmIgn} to join.\n`
 
         // dm the user and send a message in the application channel
         application_channel = await client.channels.fetch(application_channel);
-        dm.send(accepted_message);
-        application_channel.send(accepted_message);
+        await dm.send(accepted_message);
+        await application_channel.send(accepted_message);
 
         // delete the message
         await interaction.message.delete();
         console.log("accept");
     } catch (error) {
         console.error('Error accepting user:', error);
-        interaction.reply({ content: `An error occurred while accepting the user: ${error.message}`, ephemeral: true });
+        await interaction.reply({ content: `An error occurred while accepting the user: ${error.message}`, ephemeral: true });
     }
 }
 
@@ -442,15 +442,15 @@ const handle_guild_reject = async (interaction, db, client) => {
         switch(guildName) {
             case 'Ironman Sweats':
                 channel = await client.channels.fetch(IMS_application_channel);
-                channel.send(`${ign} (<@${userid}>) has been rejected by ${interaction.user}!`);
+                await channel.send(`${ign} (<@${userid}>) has been rejected by ${interaction.user}!`);
                 break;
             case 'Ironman Casuals':
                 channel = await client.channels.fetch(IMC_application_channel);
-                channel.send(`${ign} (<@${userid}>) has been rejected by ${interaction.user}!`);
+                await channel.send(`${ign} (<@${userid}>) has been rejected by ${interaction.user}!`);
                 break;
             case 'Ironman Academy':
                 channel = await client.channels.fetch(IMA_application_channel);
-                channel.send(`${ign} (<@${userid}>) has been rejected by ${interaction.user}!`);
+                await channel.send(`${ign} (<@${userid}>) has been rejected by ${interaction.user}!`);
                 break;
         }
 
@@ -467,9 +467,9 @@ const handle_guild_reject = async (interaction, db, client) => {
 
         // dm the user and send a message in the application channel
         const dm = await member.createDM();
-        dm.send(rejection_message);
+        await dm.send(rejection_message);
         application_channel = await client.channels.fetch(application_channel);
-        application_channel.send(rejection_message);
+        await application_channel.send(rejection_message);
 
         // Create a close channel button
         const CloseButton = new ActionRowBuilder()
@@ -486,7 +486,7 @@ const handle_guild_reject = async (interaction, db, client) => {
     }
     catch (error) {
         console.error('Error rejecting user:', error);
-        interaction.reply({ content: `An error occurred while rejecting the user: ${error.message}`, ephemeral: true });
+        await interaction.reply({ content: `An error occurred while rejecting the user: ${error.message}`, ephemeral: true });
     }
 }
 
@@ -499,7 +499,7 @@ const handle_application_close = async (interaction, db, client) => {
         await application_channel.delete();
     } catch (error) {
         console.error('Error closing application channel:', error);
-        interaction.reply({ content: `An error occurred while closing the application channel: ${error.message}`, ephemeral: true });
+        await interaction.reply({ content: `An error occurred while closing the application channel: ${error.message}`, ephemeral: true });
     }
 }
 
@@ -534,7 +534,7 @@ const handle_guild_invited = async (interaction, db, client) => {
         await interaction.message.delete();
     } catch (error) {
         console.error('Error inviting user:', error);
-        interaction.reply({ content: `An error occurred while inviting the user: ${error.message}`, ephemeral: true });
+        await interaction.reply({ content: `An error occurred while inviting the user: ${error.message}`, ephemeral: true });
     }
 }
 
@@ -559,15 +559,15 @@ const handle_guild_ask_to_leave = async (interaction, db, client) => {
         let ask_to_leave_message = `It is your turn to be invited to ${guildName}. Please leave your guild so you can get invited. <@${userid}>`;
 
         const dm = await member.createDM();
-        dm.send(ask_to_leave_message);
+        await dm.send(ask_to_leave_message);
 
-        application_channel.send(ask_to_leave_message);
+        await application_channel.send(ask_to_leave_message);
 
-        interaction.reply({ content: `${ign} has been asked to leave their guild`, ephemeral: true });
+        await interaction.reply({ content: `${ign} has been asked to leave their guild`, ephemeral: true });
         console.log(`    ${ign} has been asked to leave their guild`)
     } catch (error) {
         console.error('Error asking user to leave:', error);
-        interaction.reply({ content: `An error occurred while asking the user to leave: ${error.message}`, ephemeral: true });
+        await interaction.reply({ content: `An error occurred while asking the user to leave: ${error.message}`, ephemeral: true });
     }
 }
 
@@ -604,15 +604,15 @@ If you missed the invite, don't worry, you will receive another one.
 You can also type /guild accept ${gmIgn} to join. <@${userid}>`;
 
         const dm = await member.createDM();
-        dm.send(notify_invited_message);
+        await dm.send(notify_invited_message);
 
-        application_channel.send(notify_invited_message);
+        await application_channel.send(notify_invited_message);
 
-        interaction.reply({ content: `${ign} has been notified of their invite`, ephemeral: true });
+        await interaction.reply({ content: `${ign} has been notified of their invite`, ephemeral: true });
         console.log(`    ${ign} has been invited to ${guildName}`);
     } catch (error) {
         console.error('Error notifying user to leave:', error);
-        interaction.reply({ content: `An error occurred while notifying the user to leave: ${error.message}`, ephemeral: true });
+        await interaction.reply({ content: `An error occurred while notifying the user to leave: ${error.message}`, ephemeral: true });
     }
 }
 

--- a/src/bot/commands/mute_restrict_ban.js
+++ b/src/bot/commands/mute_restrict_ban.js
@@ -126,7 +126,7 @@ const unban_command = new SlashCommandBuilder()
             .setRequired(true));
 
 const ban_interaction = async (interaction, db) => {
-    interaction.deferReply();
+    await interaction.deferReply();
     const user = interaction.options.getUser('user');
     let reason = interaction.options.getString('reason');
 
@@ -219,12 +219,12 @@ const ban_interaction = async (interaction, db) => {
         await interaction.editReply(reply_string);
     } catch (error) {
         console.error('Error banning user:', error);
-        interaction.editReply(`An error occurred while trying to ban the user: ${error}`);
+        await interaction.editReply(`An error occurred while trying to ban the user: ${error}`);
     }
 }
 
 const unban_interaction = async (interaction, db) => {
-    interaction.deferReply();
+    await interaction.deferReply();
     console.log('Unbanning user');
     try {
         const user_id = interaction.options.getString('user_id');
@@ -242,12 +242,12 @@ const unban_interaction = async (interaction, db) => {
         await log_action(interaction.client, `Unban`, interaction.user, `${user_id}`, `${user_id} was unbanned.`);
     } catch (error) {
         console.error('Error unbanning user:', error);
-        interaction.editReply(`An error occurred while trying to unban the user: ${error}`);
+        await interaction.editReply(`An error occurred while trying to unban the user: ${error}`);
     }
 }
 
 const lfp_restrict_interaction = async (interaction, db) => {
-    interaction.deferReply();
+    await interaction.deferReply();
     const user = interaction.options.getUser('user');
     const type = interaction.options.getString('type');
     const durationInput = interaction.options.getString('duration');
@@ -448,12 +448,12 @@ const lfp_restrict_interaction = async (interaction, db) => {
 
     } catch (error) {
         console.error('Error applying LFP restriction:', error);
-        interaction.editReply(`An error occurred while trying to punish the user: ${error}`);
+        await interaction.editReply(`An error occurred while trying to punish the user: ${error}`);
     }
 };
 
 const punish_interaction = async (interaction, db, punishment_type) => {
-    interaction.deferReply();
+    await interaction.deferReply();
     const user = interaction.options.getUser('user');
     const duration = interaction.options.getString('duration');
     const reason = interaction.options.getString('reason');
@@ -667,7 +667,7 @@ const punish_interaction = async (interaction, db, punishment_type) => {
 
     } catch (error) {
         console.error('Error muting user:', error);
-        interaction.editReply(`An error occurred while trying to punish the user: ${error}`);
+        await interaction.editReply(`An error occurred while trying to punish the user: ${error}`);
     }
 };
 

--- a/src/bot/commands/punishments.js
+++ b/src/bot/commands/punishments.js
@@ -212,9 +212,13 @@ const punishments_interaction = async (interaction, db, subcommand) => {
                 });
             });
         
-            collector.on('end', () => {
+            collector.on('end', async () => {
                 row.components.forEach(button => button.setDisabled(true));
-                interaction.editReply({ components: [row] });
+                try {
+                    await interaction.editReply({ components: [row] });
+                } catch (error) {
+                    console.error('Error disabling punishments pagination buttons:', error);
+                }
             });
             
         }

--- a/src/bot/commands/rank_guild.js
+++ b/src/bot/commands/rank_guild.js
@@ -161,9 +161,13 @@ const create_embed = async (interaction, title, description, rows) => {
         });
     });
 
-    collector.on('end', () => {
+    collector.on('end', async () => {
         row.components.forEach(button => button.setDisabled(true));
-        interaction.editReply({ components: [row] });
+        try {
+            await interaction.editReply({ components: [row] });
+        } catch (error) {
+            console.error('Error disabling rank guild pagination buttons:', error);
+        }
     });
 }
 

--- a/src/bot/commands/skycrypt.js
+++ b/src/bot/commands/skycrypt.js
@@ -16,7 +16,7 @@ const skycrypt_interaction = async (interaction, db) => {
 
         console.log(`    IGN: ${ign}`)
 
-        const skycrypt = `https://sky.shiiyu.moe/stats/${ign}`;
+        const skycrypt = `https://sky.shiiiyu.moe/stats/${ign}`;
 
         await interaction.reply(`The skycrypt of \`${ign}\` is: \n${skycrypt}`);
     } catch (error) {

--- a/src/bot/commands/sync_roles.js
+++ b/src/bot/commands/sync_roles.js
@@ -64,7 +64,7 @@ const sync_roles_command = new SlashCommandBuilder()
 const sync_roles_interaction = async (interaction, db) => {
     console.log('Syncing roles')
     if (interaction.isCommand()) {
-        interaction.deferReply();
+        await interaction.deferReply();
     }
     // Sync guild info
     try {
@@ -75,7 +75,11 @@ const sync_roles_interaction = async (interaction, db) => {
         let sql = `SELECT uuid, ign FROM members WHERE discord_id = ?`;
         let [rows] = await db.query(sql, [discord_id]);
         if (rows.length === 0) {
-            await interaction.reply('You are not verified');
+            if (interaction.isCommand()) {
+                await interaction.editReply('You are not verified');
+            } else {
+                await interaction.reply('You are not verified');
+            }
             return;
         }
         const uuid = rows[0].uuid;

--- a/src/bot/commands/verify.js
+++ b/src/bot/commands/verify.js
@@ -258,11 +258,11 @@ const verify_interaction = async (interaction, db, opts) => {
         ephemeral = false;
     }
     const discord_id = interaction.user.id;
-    interaction.deferReply({ ephemeral: ephemeral });
+    await interaction.deferReply({ ephemeral: ephemeral });
 
     console.log(`Verifying ${discord_username} with IGN ${ign}`)
     try {
-        verified = await verifyMember(interaction, discord_username, ign, discord_id, db);
+        const verified = await verifyMember(interaction, discord_username, ign, discord_id, db);
 
         if (verified.startsWith("success")) {
             // Add verified role to user


### PR DESCRIPTION
## Summary
- add a top-level interaction error handler so command, button, and modal failures are logged and return a controlled response
- await Discord replies, sends, and edits that could otherwise race or reject in the background
- keep automod channel lookup inside the message-processing error handling
- catch pagination cleanup failures when disabling expired controls